### PR TITLE
AutoDisconnect and CombatDisconnect

### DIFF
--- a/Wurst Client/src/tk/wurst_client/mods/AutoDisconnect.java
+++ b/Wurst Client/src/tk/wurst_client/mods/AutoDisconnect.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2014 - 2015 | Alexander01998 | All rights reserved.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package tk.wurst_client.mods;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.play.client.C01PacketChatMessage;
+import tk.wurst_client.events.EventManager;
+import tk.wurst_client.events.listeners.UpdateListener;
+import tk.wurst_client.mods.Mod.Category;
+import tk.wurst_client.mods.Mod.Info;
+
+@Info(category = Category.COMBAT,
+	description = "Auto disconnects you if your health\n"
+		+ "gets below 4 hearts.\n"
+		+ "It can bypass combat logger.",
+	name = "AutoDisconnect")
+public class AutoDisconnect extends Mod implements UpdateListener
+{
+	
+	@Override
+	public void onEnable()
+	{
+		EventManager.update.addListener(this);
+	}
+
+	@Override
+	public void onUpdate()
+	{
+
+		float health = Minecraft.getMinecraft().thePlayer.getHealth();
+		
+		if(health <= 8.0F && !Minecraft.getMinecraft().thePlayer.capabilities.isCreativeMode
+				&& (!Minecraft.getMinecraft().isIntegratedServerRunning()
+				|| Minecraft.getMinecraft().thePlayer.sendQueue.getPlayerInfo().size() > 1))
+		{
+		Minecraft.getMinecraft().thePlayer.sendQueue
+		.addToSendQueue(new C01PacketChatMessage("§"));
+		setEnabled(false);
+		}
+		
+
+	}
+	
+	@Override
+	public void onDisable()
+	{
+		EventManager.update.removeListener(this);
+	}
+}

--- a/Wurst Client/src/tk/wurst_client/mods/AutoDisconnectMod.java
+++ b/Wurst Client/src/tk/wurst_client/mods/AutoDisconnectMod.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2014 - 2015 | Alexander01998 | All rights reserved.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package tk.wurst_client.mods;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.play.client.C01PacketChatMessage;
+import tk.wurst_client.events.EventManager;
+import tk.wurst_client.events.listeners.UpdateListener;
+import tk.wurst_client.mods.Mod.Category;
+import tk.wurst_client.mods.Mod.Info;
+
+@Info(category = Category.COMBAT,
+	description = "Auto disconnects you if your health\n"
+		+ "gets below 4 hearts.\n"
+		+ "It can bypass combat logger.",
+	name = "AutoDisconnect")
+public class AutoDisconnectMod extends Mod implements UpdateListener
+{
+	
+	@Override
+	public void onEnable()
+	{
+		EventManager.update.addListener(this);
+	}
+
+	@Override
+	public void onUpdate()
+	{
+
+		float health = Minecraft.getMinecraft().thePlayer.getHealth();
+		
+		if(health <= 8.0F && !Minecraft.getMinecraft().thePlayer.capabilities.isCreativeMode
+				&& (!Minecraft.getMinecraft().isIntegratedServerRunning()
+				|| Minecraft.getMinecraft().thePlayer.sendQueue.getPlayerInfo().size() > 1))
+		{
+		Minecraft.getMinecraft().thePlayer.sendQueue
+		.addToSendQueue(new C01PacketChatMessage("§"));
+		setEnabled(false);
+		}
+		
+
+	}
+	
+	@Override
+	public void onDisable()
+	{
+		EventManager.update.removeListener(this);
+	}
+}

--- a/Wurst Client/src/tk/wurst_client/mods/CombatDisconnectMod.java
+++ b/Wurst Client/src/tk/wurst_client/mods/CombatDisconnectMod.java
@@ -9,46 +9,32 @@ package tk.wurst_client.mods;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.play.client.C01PacketChatMessage;
-import tk.wurst_client.events.EventManager;
-import tk.wurst_client.events.listeners.UpdateListener;
 import tk.wurst_client.mods.Mod.Category;
 import tk.wurst_client.mods.Mod.Info;
 
 @Info(category = Category.COMBAT,
-	description = "Auto disconnects you if your health\n"
-		+ "gets below 4 hearts.\n"
-		+ "It can bypass combat logger.",
-	name = "AutoDisconnect")
-public class AutoDisconnect extends Mod implements UpdateListener
+	description = "Instantly disconnects you from the server.\n"
+		+ "Can be keybinded for panic disconnects.\n"
+		+ "It bypass combat logger. (only works on servers)",
+	name = "CBTDisconnect")
+public class CombatDisconnectMod extends Mod
 {
 	
 	@Override
 	public void onEnable()
 	{
-		EventManager.update.addListener(this);
-	}
-
-	@Override
-	public void onUpdate()
-	{
-
-		float health = Minecraft.getMinecraft().thePlayer.getHealth();
-		
-		if(health <= 8.0F && !Minecraft.getMinecraft().thePlayer.capabilities.isCreativeMode
-				&& (!Minecraft.getMinecraft().isIntegratedServerRunning()
+		if((!Minecraft.getMinecraft().isIntegratedServerRunning()
 				|| Minecraft.getMinecraft().thePlayer.sendQueue.getPlayerInfo().size() > 1))
 		{
 		Minecraft.getMinecraft().thePlayer.sendQueue
 		.addToSendQueue(new C01PacketChatMessage("§"));
 		setEnabled(false);
 		}
-		
-
+		setEnabled(false);
 	}
 	
 	@Override
 	public void onDisable()
 	{
-		EventManager.update.removeListener(this);
 	}
 }

--- a/Wurst Client/src/tk/wurst_client/mods/ModManager.java
+++ b/Wurst Client/src/tk/wurst_client/mods/ModManager.java
@@ -35,7 +35,7 @@ public class ModManager
 		addMod(new AntiSpamMod());
 		addMod(new ArenaBrawlMod());
 		addMod(new AutoArmorMod());
-		addMod(new AutoDisconnect());
+		addMod(new AutoDisconnectMod());
 		addMod(new AutoEatMod());
 		addMod(new AutoFishMod());
 		addMod(new AutoMineMod());
@@ -54,6 +54,7 @@ public class ModManager
 		addMod(new BunnyHopMod());
 		addMod(new ChestEspMod());
 		addMod(new ClickGuiMod());
+		addMod(new CombatDisconnectMod());
 		addMod(new CriticalsMod());
 		addMod(new DerpMod());
 		addMod(new DolphinMod());

--- a/Wurst Client/src/tk/wurst_client/mods/ModManager.java
+++ b/Wurst Client/src/tk/wurst_client/mods/ModManager.java
@@ -35,6 +35,7 @@ public class ModManager
 		addMod(new AntiSpamMod());
 		addMod(new ArenaBrawlMod());
 		addMod(new AutoArmorMod());
+		addMod(new AutoDisconnect());
 		addMod(new AutoEatMod());
 		addMod(new AutoFishMod());
 		addMod(new AutoMineMod());


### PR DESCRIPTION
Autodisconnect disconnects you when your health is below 4 hearts, and combatdisconnect, is for panic  disconnect. Like, you are running from a daumm op pay4win donator and enable CBTDisconnect to disconnect bypassing combat logger.

Oh, I added.
```java
(!Minecraft.getMinecraft().isIntegratedServerRunning()
+ || Minecraft.getMinecraft().thePlayer.sendQueue.getPlayerInfo().size() > 1)
```
To it **does'nt** run on single-player and don't crash the game (sometimes it crashes, sometimes not, idk why) .

Resolves #461 .