### PR TITLE
Fix Freecam Particle Crash

### DIFF
--- a/patch/minecraft.patch
+++ b/patch/minecraft.patch
@@ -10344,7 +10344,7 @@ index f503b64..2f339db 100644
 +
 +            this.mcProfiler.endStartSection("animateTick");
 +
-+            if (!this.isGamePaused && this.theWorld != null)
++            if (!this.isGamePaused && this.theWorld != null && !WurstClient.INSTANCE.modManager.getModByName("Freecam").isEnabled())
 +            {
 +                this.theWorld.doVoidFogParticles(MathHelper.floor_double(this.thePlayer.posX), MathHelper.floor_double(this.thePlayer.posY), MathHelper.floor_double(this.thePlayer.posZ));
 +            }


### PR DESCRIPTION
Workaround Fix for the Water on Double Slab crash.

Prevent particles from appearing when Freecam is enabled.
(prevent this.theWorld.doVoidFogParticles)

Fix: #124 