### PR TITLE
More reliable Google results

### DIFF
--- a/Wurst Client/src/tk/wurst_client/alts/gui/SessionStealerScreen.java
+++ b/Wurst Client/src/tk/wurst_client/alts/gui/SessionStealerScreen.java
@@ -129,7 +129,7 @@ public class SessionStealerScreen extends GuiScreen
 				}
 			}else if(button.id == 2)
 				MiscUtils
-					.openLink("https://www.google.com/search?q=%22session+id+is+token%22&tbs=qdr:m");
+					.openLink("https://www.google.com/search?q=%22session+id+is+token%22&tbs=qdr:d");
 	}
 	
 	/**


### PR DESCRIPTION
Now gets only entries of the last day. I first thought, a week would be
better, but Google then shows almost the same amount of results,
excluding the up-to-date ones.