### PR TITLE
AntiChatFilter mod

### DIFF
--- a/Wurst Client/src/tk/wurst_client/mods/AntiChatFilterMod.java
+++ b/Wurst Client/src/tk/wurst_client/mods/AntiChatFilterMod.java
@@ -1,0 +1,48 @@
+package tk.wurst_client.mods;
+
+import tk.wurst_client.WurstClient;
+import tk.wurst_client.events.ChatOutputEvent;
+import tk.wurst_client.events.listeners.ChatOutputListener;
+import tk.wurst_client.mods.Mod.Category;
+import tk.wurst_client.mods.Mod.Info;
+
+@Info(category = Category.CHAT,
+	description = "Uses a special font to bypass some\n"
+		+ "Word and Capslock filters.",
+	name = "AntiChatFilter")
+public class AntiChatFilterMod extends Mod implements ChatOutputListener
+{
+	private final String blacklist = "({[|]})";
+	
+	@Override
+	public void onEnable()
+	{
+		WurstClient.INSTANCE.events.add(ChatOutputListener.class, this);
+	}
+	
+	@Override
+	public void onSentMessage(ChatOutputEvent event)
+	{
+		if(event.getMessage().startsWith("/"))
+			return;
+			
+		String out = "";
+		
+		for(char chr : event.getMessage().toCharArray())
+		{
+			if(chr >= 0x21 && chr <= 0x80
+				&& !blacklist.contains(Character.toString(chr)))
+				out += new String(Character.toChars(((int)chr) + 0xFEE0));
+			else
+				out += chr;
+		}
+		
+		event.setMessage(out);
+	}
+	
+	@Override
+	public void onDisable()
+	{
+		WurstClient.INSTANCE.events.remove(ChatOutputListener.class, this);
+	}
+}

--- a/Wurst Client/src/tk/wurst_client/mods/AntiChatFilterMod.java
+++ b/Wurst Client/src/tk/wurst_client/mods/AntiChatFilterMod.java
@@ -23,7 +23,7 @@ public class AntiChatFilterMod extends Mod implements ChatOutputListener
 	@Override
 	public void onSentMessage(ChatOutputEvent event)
 	{
-		if(event.getMessage().startsWith("/"))
+		if(event.getMessage().startsWith("/") || event.getMessage().startsWith("."))
 			return;
 			
 		String out = "";

--- a/Wurst Client/src/tk/wurst_client/mods/AntiMacMod.java
+++ b/Wurst Client/src/tk/wurst_client/mods/AntiMacMod.java
@@ -46,6 +46,9 @@ public class AntiMacMod extends Mod
 			blockedMods.remove(WurstClient.INSTANCE.mods.noSlowdownMod);
 			blockedMods.remove(WurstClient.INSTANCE.mods.regenMod);
 			blockedMods.remove(WurstClient.INSTANCE.mods.spiderMod);
+			
+			// block AntiChatFilter because Mineplex disables special characters
+			blockedMods.add(WurstClient.INSTANCE.mods.antiChatFilterMod);
 		}
 		for(Mod mod : blockedMods)
 			mod.setBlocked(true);

--- a/Wurst Client/src/tk/wurst_client/mods/ModManager.java
+++ b/Wurst Client/src/tk/wurst_client/mods/ModManager.java
@@ -28,6 +28,7 @@ public class ModManager
 	public final AntiAfkMod antiAfkMod = new AntiAfkMod();
 	public final AntiBlindMod antiBlindMod = new AntiBlindMod();
 	public final AntiCactusMod antiCactusMod = new AntiCactusMod();
+	public final AntiChatFilterMod antiChatFilterMod = new AntiChatFilterMod();
 	public final AntiFireMod antiFireMod = new AntiFireMod();
 	public final AntiKnockbackMod antiKnockbackMod = new AntiKnockbackMod();
 	public final AntiMacMod antiMacMod = new AntiMacMod();

--- a/patch/minecraft.patch
+++ b/patch/minecraft.patch
@@ -1620,7 +1620,7 @@ index eefe303..e1eac90 100644
 +      	if(event.isCancelled())
 +      		return;
 +      	
-         this.sendQueue.addToSendQueue(new C01PacketChatMessage(p_71165_1_));
+         this.sendQueue.addToSendQueue(new C01PacketChatMessage(event.getMessage()));
      }
  
      /**
@@ -1635,7 +1635,7 @@ index eefe303..e1eac90 100644
 +      	if(event.isCancelled())
 +      		return;
 +      	
-+        this.sendQueue.addToSendQueue(new C01PacketChatMessage(message));
++        this.sendQueue.addToSendQueue(new C01PacketChatMessage(event.getMessage()));
 +    }
 +
 +    /**


### PR DESCRIPTION
This mod uses special unicode characters, which are not being recognized by the most Curse Word or Caps Lock filters. Tested on DustMC and BergwerkLabs (german servers). The characters look like normal characters but in a different font. This does not work for every character, just for the basic printable ASCII ones, excluding some which caused problems.

![hax](https://cloud.githubusercontent.com/assets/10467401/12372712/fefd2bce-bc60-11e5-9932-b4afc8248333.PNG)
