### PR TITLE
Better ServerFinder

### DIFF
--- a/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiCleanUp.java
+++ b/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiCleanUp.java
@@ -26,24 +26,24 @@ public class GuiCleanUp extends GuiScreen
 {
 	private GuiMultiplayer prevMenu;
 	private boolean removeAll;
-	private String[] toolTips =
-		{
-			"",
-			"Start the Clean Up with the settings\n" + "you specified above.\n"
-				+ "It might look like the game is not\n"
-				+ "reacting for a couple of seconds.",
-			"Servers that clearly don't exist.",
-			"Servers that run a different Minecraft\n" + "version than you.",
-			"All servers that failed the last ping.\n"
-				+ "Make sure that the last ping is complete\n"
-				+ "before you do this. That means: Go back,\n"
-				+ "press the refresh button and wait until\n"
-				+ "all servers are done refreshing.",
-			"This will completely clear your server\n"
-				+ "list. §cUse with caution!§r",
-			"Renames your servers to \"Grief me #1\",\n"
-				+ "\"Grief me #2\", etc.",};
-	
+	private String[] toolTips = {"",
+		"Start the Clean Up with the settings\n" + "you specified above.\n"
+			+ "It might look like the game is not\n"
+			+ "reacting for a couple of seconds.",
+		"Servers that clearly don't exist.",
+		"Servers that run a different Minecraft\n" + "version than you.",
+		"All servers that failed the last ping.\n"
+			+ "Make sure that the last ping is complete\n"
+			+ "before you do this. That means: Go back,\n"
+			+ "press the refresh button and wait until\n"
+			+ "all servers are done refreshing.",
+		"All servers which name starts with \"Grief me\"\n"
+			+ "Useful if ServerFinder spammed up your server list.",
+		"This will completely clear your server\n"
+			+ "list. §cUse with caution!§r",
+		"Renames your servers to \"Grief me #1\",\n"
+			+ "\"Grief me #2\", etc.",};
+			
 	public GuiCleanUp(GuiMultiplayer prevMultiplayerMenu)
 	{
 		prevMenu = prevMultiplayerMenu;
@@ -54,8 +54,8 @@ public class GuiCleanUp extends GuiScreen
 	 */
 	@Override
 	public void updateScreen()
-	{	
-		
+	{
+	
 	}
 	
 	/**
@@ -67,9 +67,9 @@ public class GuiCleanUp extends GuiScreen
 	{
 		Keyboard.enableRepeatEvents(true);
 		buttonList.clear();
-		buttonList.add(new GuiButton(0, width / 2 - 100, height / 4 + 144 + 12,
-			"Cancel"));
-		buttonList.add(new GuiButton(1, width / 2 - 100, height / 4 + 120 + 12,
+		buttonList.add(
+			new GuiButton(0, width / 2 - 100, height / 4 + 144 + 12, "Cancel"));
+		buttonList.add(new GuiButton(1, width / 2 - 100, height / 4 + 168 + 12,
 			"Clean Up"));
 		buttonList.add(new GuiButton(2, width / 2 - 100, height / 4 - 24 + 12,
 			"Unknown Hosts: "
@@ -81,8 +81,11 @@ public class GuiCleanUp extends GuiScreen
 			"Failed Ping: "
 				+ removeOrKeep(WurstClient.INSTANCE.options.cleanupFailed)));
 		buttonList.add(new GuiButton(5, width / 2 - 100, height / 4 + 48 + 12,
-			"§cRemove all Servers: " + yesOrNo(removeAll)));
+			"\"Grief Me\" Servers: "
+				+ removeOrKeep(WurstClient.INSTANCE.options.cleanupGriefMe)));
 		buttonList.add(new GuiButton(6, width / 2 - 100, height / 4 + 72 + 12,
+			"§cRemove all Servers: " + yesOrNo(removeAll)));
+		buttonList.add(new GuiButton(7, width / 2 - 100, height / 4 + 96 + 12,
 			"Rename all Servers: "
 				+ yesOrNo(WurstClient.INSTANCE.options.cleanupRename)));
 		WurstClient.INSTANCE.analytics.trackPageView("/multiplayer/clean-up",
@@ -127,18 +130,21 @@ public class GuiCleanUp extends GuiScreen
 					mc.displayGuiScreen(prevMenu);
 					return;
 				}
-				for(int i = prevMenu.savedServerList.countServers() - 1; i >= 0; i--)
+				for(int i =
+					prevMenu.savedServerList.countServers() - 1; i >= 0; i--)
 				{
 					ServerData server =
 						prevMenu.savedServerList.getServerData(i);
-					if(WurstClient.INSTANCE.options.cleanupUnknown
+					if((WurstClient.INSTANCE.options.cleanupUnknown
 						&& server.serverMOTD.equals(EnumChatFormatting.DARK_RED
-							+ "Can\'t resolve hostname")
-						|| WurstClient.INSTANCE.options.cleanupOutdated
-						&& server.version != 47
-						|| WurstClient.INSTANCE.options.cleanupFailed
-						&& server.pingToServer != -2L
-						&& server.pingToServer < 0L)
+							+ "Can\'t resolve hostname"))
+						|| (WurstClient.INSTANCE.options.cleanupOutdated
+							&& server.version != 47)
+						|| (WurstClient.INSTANCE.options.cleanupFailed
+							&& server.pingToServer != -2L
+							&& server.pingToServer < 0L)
+						|| (WurstClient.INSTANCE.options.cleanupGriefMe
+							&& server.serverName.startsWith("Grief me #")))
 					{
 						prevMenu.savedServerList.removeServerData(i);
 						prevMenu.savedServerList.saveServerList();
@@ -148,7 +154,8 @@ public class GuiCleanUp extends GuiScreen
 					}
 				}
 				if(WurstClient.INSTANCE.options.cleanupRename)
-					for(int i = 0; i < prevMenu.savedServerList.countServers(); i++)
+					for(int i = 0; i < prevMenu.savedServerList
+						.countServers(); i++)
 					{
 						ServerData server =
 							prevMenu.savedServerList.getServerData(i);
@@ -163,9 +170,8 @@ public class GuiCleanUp extends GuiScreen
 			{// Unknown host
 				WurstClient.INSTANCE.options.cleanupUnknown =
 					!WurstClient.INSTANCE.options.cleanupUnknown;
-				clickedButton.displayString =
-					"Unknown Hosts: "
-						+ removeOrKeep(WurstClient.INSTANCE.options.cleanupUnknown);
+				clickedButton.displayString = "Unknown Hosts: "
+					+ removeOrKeep(WurstClient.INSTANCE.options.cleanupUnknown);
 				WurstClient.INSTANCE.files.saveOptions();
 				WurstClient.INSTANCE.analytics.trackEvent("clean up",
 					"unknown host",
@@ -175,8 +181,8 @@ public class GuiCleanUp extends GuiScreen
 				WurstClient.INSTANCE.options.cleanupOutdated =
 					!WurstClient.INSTANCE.options.cleanupOutdated;
 				clickedButton.displayString =
-					"Outdated Servers: "
-						+ removeOrKeep(WurstClient.INSTANCE.options.cleanupOutdated);
+					"Outdated Servers: " + removeOrKeep(
+						WurstClient.INSTANCE.options.cleanupOutdated);
 				WurstClient.INSTANCE.files.saveOptions();
 				WurstClient.INSTANCE.analytics.trackEvent("clean up",
 					"outdated servers",
@@ -185,27 +191,34 @@ public class GuiCleanUp extends GuiScreen
 			{// Failed ping
 				WurstClient.INSTANCE.options.cleanupFailed =
 					!WurstClient.INSTANCE.options.cleanupFailed;
-				clickedButton.displayString =
-					"Failed Ping: "
-						+ removeOrKeep(WurstClient.INSTANCE.options.cleanupFailed);
+				clickedButton.displayString = "Failed Ping: "
+					+ removeOrKeep(WurstClient.INSTANCE.options.cleanupFailed);
 				WurstClient.INSTANCE.files.saveOptions();
 				WurstClient.INSTANCE.analytics.trackEvent("clean up",
 					"failed ping",
 					removeOrKeep(WurstClient.INSTANCE.options.cleanupFailed));
 			}else if(clickedButton.id == 5)
+			{// Grief me
+				WurstClient.INSTANCE.options.cleanupGriefMe =
+					!WurstClient.INSTANCE.options.cleanupGriefMe;
+				WurstClient.INSTANCE.files.saveOptions();
+				clickedButton.displayString = "\"Grief Me\" Servers: "
+					+ removeOrKeep(WurstClient.INSTANCE.options.cleanupGriefMe);
+				WurstClient.INSTANCE.analytics.trackEvent("clean up", "griefme",
+					removeOrKeep(WurstClient.INSTANCE.options.cleanupGriefMe));
+			}else if(clickedButton.id == 6)
 			{// Remove
 				removeAll = !removeAll;
 				clickedButton.displayString =
 					"§cRemove all Servers: " + yesOrNo(removeAll);
 				WurstClient.INSTANCE.analytics.trackEvent("clean up",
 					"remove all servers", yesOrNo(removeAll));
-			}else if(clickedButton.id == 6)
+			}else if(clickedButton.id == 7)
 			{// Rename
 				WurstClient.INSTANCE.options.cleanupRename =
 					!WurstClient.INSTANCE.options.cleanupRename;
-				clickedButton.displayString =
-					"Rename all Servers: "
-						+ yesOrNo(WurstClient.INSTANCE.options.cleanupRename);
+				clickedButton.displayString = "Rename all Servers: "
+					+ yesOrNo(WurstClient.INSTANCE.options.cleanupRename);
 				WurstClient.INSTANCE.files.saveOptions();
 				WurstClient.INSTANCE.analytics.trackEvent("clean up",
 					"rename servers",
@@ -230,8 +243,7 @@ public class GuiCleanUp extends GuiScreen
 	 * @throws IOException
 	 */
 	@Override
-	protected void mouseClicked(int par1, int par2, int par3)
-		throws IOException
+	protected void mouseClicked(int par1, int par2, int par3) throws IOException
 	{
 		super.mouseClicked(par1, par2, par3);
 	}
@@ -243,7 +255,8 @@ public class GuiCleanUp extends GuiScreen
 	public void drawScreen(int par1, int par2, float par3)
 	{
 		drawDefaultBackground();
-		drawCenteredString(fontRendererObj, "Clean Up", width / 2, 20, 16777215);
+		drawCenteredString(fontRendererObj, "Clean Up", width / 2, 20,
+			16777215);
 		drawCenteredString(fontRendererObj,
 			"Please select the servers you want to remove:", width / 2, 36,
 			10526880);

--- a/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiServerFinder.java
+++ b/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiServerFinder.java
@@ -215,6 +215,9 @@ public class GuiServerFinder extends GuiScreen
 								WurstClient.INSTANCE.analytics.trackEvent(
 									"server finder", "unknown host",
 									"unknown host", working);
+							}catch(Exception e) {
+								e.printStackTrace();
+								state = ServerFinderState.ERROR;
 							}
 						}
 					}.start();

--- a/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiServerFinder.java
+++ b/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiServerFinder.java
@@ -214,10 +214,13 @@ public class GuiServerFinder extends GuiScreen
 								state = ServerFinderState.UNKNOWN_HOST;
 								WurstClient.INSTANCE.analytics.trackEvent(
 									"server finder", "unknown host",
-									"unknown host", working);
+									"unknown host");
 							}catch(Exception e) {
 								e.printStackTrace();
 								state = ServerFinderState.ERROR;
+								WurstClient.INSTANCE.analytics.trackEvent(
+									"server finder", "error",
+									"error");
 							}
 						}
 					}.start();

--- a/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiServerFinder.java
+++ b/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiServerFinder.java
@@ -228,6 +228,15 @@ public class GuiServerFinder extends GuiScreen
 				mc.displayGuiScreen(prevMenu);
 	}
 	
+	private boolean serverInList(String ip) {
+		for (int i = 0; i < prevMenu.savedServerList.countServers(); i++) {
+			if (prevMenu.savedServerList.getServerData(i).serverIP.equals(ip))
+				return true;
+		}
+		
+		return false;
+	}
+	
 	private ArrayList<ServerPinger> updatePingers(
 		ArrayList<ServerPinger> pingers)
 	{
@@ -238,16 +247,19 @@ public class GuiServerFinder extends GuiScreen
 				if(pingers.get(i).isWorking())
 				{
 					GuiServerFinder.this.working++;
-					GuiServerFinder.this.prevMenu.savedServerList
-						.addServerData(new ServerData("Grief me #" + working,
-							pingers.get(i).server.serverIP));
-					GuiServerFinder.this.prevMenu.savedServerList
-						.saveServerList();
-					GuiServerFinder.this.prevMenu.serverListSelector
-						.setSelectedServer(-1);
-					GuiServerFinder.this.prevMenu.serverListSelector
-						.func_148195_a(
-							GuiServerFinder.this.prevMenu.savedServerList);
+					
+					if (!serverInList(pingers.get(i).server.serverIP)) {
+						GuiServerFinder.this.prevMenu.savedServerList
+							.addServerData(new ServerData("Grief me #" + working,
+								pingers.get(i).server.serverIP));
+						GuiServerFinder.this.prevMenu.savedServerList
+							.saveServerList();
+						GuiServerFinder.this.prevMenu.serverListSelector
+							.setSelectedServer(-1);
+						GuiServerFinder.this.prevMenu.serverListSelector
+							.func_148195_a(
+								GuiServerFinder.this.prevMenu.savedServerList);
+					}
 				}
 				pingers.remove(i);
 			}

--- a/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiServerFinder.java
+++ b/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiServerFinder.java
@@ -137,13 +137,15 @@ public class GuiServerFinder extends GuiScreen
 									.valueOf(ipBox.getText().split("\\.")[i]);
 						ArrayList<ServerPinger> pingers =
 							new ArrayList<ServerPinger>();
-						serverFinder: for(int i = 3; i >= 0; i--)
+						int[] changes = {0, 1, -1, 2, -2, 3, -3};
+						serverFinder: for(int i = 0; i < changes.length; i++)
 							for(int i2 = 0; i2 <= 255; i2++)
 							{
 								if(terminated)
 									break serverFinder;
 								int[] ipParts2 = ipParts.clone();
-								ipParts2[i] = i2;
+								ipParts2[2] = ipParts[2]+changes[i];
+								ipParts2[3] = i2;
 								String ip =
 									ipParts2[0] + "." + ipParts2[1] + "."
 										+ ipParts2[2] + "." + ipParts2[3];
@@ -280,7 +282,7 @@ public class GuiServerFinder extends GuiScreen
 					"§4Max. threads must be a number!", width / 2,
 					height / 4 + 73, 10526880);
 			else if(running)
-				if(checked == 1024)
+				if(checked == 1792)
 					drawCenteredString(fontRendererObj, "§2Done!", width / 2,
 						height / 4 + 73, 10526880);
 				else
@@ -289,7 +291,7 @@ public class GuiServerFinder extends GuiScreen
 			else
 				drawCenteredString(fontRendererObj, "§4Unknown error! Bug?",
 					width / 2, height / 4 + 73, 10526880);
-		drawString(fontRendererObj, "Checked: " + checked + " / 1024",
+		drawString(fontRendererObj, "Checked: " + checked + " / 1792",
 			width / 2 - 100, height / 4 + 84, 10526880);
 		drawString(fontRendererObj, "Working: " + working, width / 2 - 100,
 			height / 4 + 94, 10526880);

--- a/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiServerFinder.java
+++ b/Wurst Client/src/tk/wurst_client/gui/multiplayer/GuiServerFinder.java
@@ -195,7 +195,7 @@ public class GuiServerFinder extends GuiScreen
 											if(state == ServerFinderState.CANCELLED)
 												return;
 												
-											pingers = updatePingers(pingers);
+											updatePingers(pingers);
 										}
 									}
 								while(pingers.size() > 0)
@@ -203,7 +203,7 @@ public class GuiServerFinder extends GuiScreen
 									if(state == ServerFinderState.CANCELLED)
 										return;
 										
-									pingers = updatePingers(pingers);
+									updatePingers(pingers);
 								}
 								WurstClient.INSTANCE.analytics.trackEvent(
 									"server finder", "complete", "complete",
@@ -237,8 +237,7 @@ public class GuiServerFinder extends GuiScreen
 		return false;
 	}
 	
-	private ArrayList<ServerPinger> updatePingers(
-		ArrayList<ServerPinger> pingers)
+	private void updatePingers(ArrayList<ServerPinger> pingers)
 	{
 		for(int i = 0; i < pingers.size(); i++)
 			if(!pingers.get(i).isStillPinging())
@@ -263,7 +262,6 @@ public class GuiServerFinder extends GuiScreen
 				}
 				pingers.remove(i);
 			}
-		return pingers;
 	}
 	
 	/**

--- a/Wurst Client/src/tk/wurst_client/options/OptionsManager.java
+++ b/Wurst Client/src/tk/wurst_client/options/OptionsManager.java
@@ -18,6 +18,7 @@ public class OptionsManager
 	public boolean cleanupOutdated = true;
 	public boolean cleanupRename = true;
 	public boolean cleanupUnknown = true;
+	public boolean cleanupGriefMe = false;
 	public boolean forceOPDontWait = false;
 	public boolean middleClickFriends = true;
 	public boolean spamFont = false;

--- a/Wurst Client/src/tk/wurst_client/options/OptionsManager.java
+++ b/Wurst Client/src/tk/wurst_client/options/OptionsManager.java
@@ -30,7 +30,7 @@ public class OptionsManager
 	public int forceOPDelay = 1000;
 	public int ghostHandID = 54;
 	public int searchID = 116;
-	public int serverFinderThreads = 64;
+	public int serverFinderThreads = 128;
 	public int spamDelay = 1000;
 	public int throwAmount = 16;
 	


### PR DESCRIPTION
This Pull Request makes the ServerFinder way more efficient. It can find about 6 times more servers (tested using an Nitrado IP). It also adds a cleanup item to remove "Grief Me" servers. This makes it easy to get your old serverlist back without saving it.

![serverfinder-new](https://cloud.githubusercontent.com/assets/10467401/13198269/fae40ca0-d804-11e5-8f71-f31b95f57b75.PNG)
![serverfinder-old](https://cloud.githubusercontent.com/assets/10467401/13198268/fae3b0b6-d804-11e5-9486-9528e6e28b07.PNG)
![serverfinder-cleanup](https://cloud.githubusercontent.com/assets/10467401/13198283/41aa8f06-d805-11e5-88ad-8fa815db2140.PNG)
