### PR TITLE
No more Vanilla Fly Kicks

### DIFF
--- a/Wurst Client/src/tk/wurst_client/events/EventManager.java
+++ b/Wurst Client/src/tk/wurst_client/events/EventManager.java
@@ -31,6 +31,8 @@ public final class EventManager
 				fireRender();
 			else if(type == PacketInputEvent.class)
 				firePacketInput((PacketInputEvent)event);
+			else if(type == PacketOutputEvent.class)
+				firePacketOutput((PacketOutputEvent)event);
 			else if(type == UpdateEvent.class)
 				fireUpdate();
 			else if(type == ChatInputEvent.class)
@@ -105,6 +107,14 @@ public final class EventManager
 		for(int i = listeners.length - 2; i >= 0; i -= 2)
 			if(listeners[i] == PacketInputListener.class)
 				((PacketInputListener)listeners[i + 1]).onReceivedPacket(event);
+	}
+	
+	private void firePacketOutput(PacketOutputEvent event)
+	{
+		Object[] listeners = listenerList.getListenerList();
+		for(int i = listeners.length - 2; i >= 0; i -= 2)
+			if(listeners[i] == PacketOutputListener.class)
+				((PacketOutputListener)listeners[i + 1]).onSendingPacket(event);
 	}
 	
 	private void fireRender()

--- a/Wurst Client/src/tk/wurst_client/events/PacketOutputEvent.java
+++ b/Wurst Client/src/tk/wurst_client/events/PacketOutputEvent.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2014 - 2016 | Wurst-Imperium | All rights reserved.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package tk.wurst_client.events;
+
+import net.minecraft.network.Packet;
+
+public class PacketOutputEvent extends CancellableEvent
+{
+	private Packet packet;
+	
+	public PacketOutputEvent(Packet packet)
+	{
+		this.packet = packet;
+	}
+	
+	public Packet getPacket()
+	{
+		return packet;
+	}
+	
+	public void setPacket(Packet packet)
+	{
+		this.packet = packet;
+	}
+	
+	@Override
+	public String getAction()
+	{
+		return "sending packet";
+	}
+	
+	@Override
+	public String getComment()
+	{
+		return "Packet: " + packet != null ? packet.getClass().getSimpleName()
+			: "null";
+	}
+}

--- a/Wurst Client/src/tk/wurst_client/events/listeners/PacketOutputListener.java
+++ b/Wurst Client/src/tk/wurst_client/events/listeners/PacketOutputListener.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright © 2014 - 2016 | Wurst-Imperium | All rights reserved.
+ * 
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package tk.wurst_client.events.listeners;
+
+import tk.wurst_client.events.PacketOutputEvent;
+
+public interface PacketOutputListener extends Listener
+{
+	public void onSendingPacket(PacketOutputEvent event);
+}

--- a/Wurst Client/src/tk/wurst_client/mods/JetpackMod.java
+++ b/Wurst Client/src/tk/wurst_client/mods/JetpackMod.java
@@ -7,6 +7,7 @@
  */
 package tk.wurst_client.mods;
 
+import net.minecraft.network.play.client.C03PacketPlayer;
 import tk.wurst_client.events.listeners.UpdateListener;
 import tk.wurst_client.mods.Mod.Category;
 import tk.wurst_client.mods.Mod.Info;
@@ -27,10 +28,42 @@ public class JetpackMod extends Mod implements UpdateListener
 	}
 	
 	@Override
+	public void initSettings()
+	{
+		settings.add(FlightMod.bypassKick);
+	}
+	
+	@Override
+	public String getRenderName()
+	{
+		if(!FlightMod.bypassKick.isChecked())
+			return getName();
+			
+		return getName() + (wurst.mods.flightMod.flyHeight <= 300
+			? "[Kick: Safe]" : "[Kick: Unsafe]");
+	}
+	
+	@Override
 	public void onUpdate()
 	{
+		updateMS();
+		
 		if(mc.gameSettings.keyBindJump.pressed)
 			mc.thePlayer.jump();
+			
+		if(FlightMod.bypassKick.isChecked())
+		{
+			wurst.mods.flightMod.updateFlyHeight();
+			mc.thePlayer.sendQueue.addToSendQueue(new C03PacketPlayer(true));
+			
+			if((wurst.mods.flightMod.flyHeight <= 290 && hasTimePassedM(500))
+				|| (wurst.mods.flightMod.flyHeight > 290
+					&& hasTimePassedM(100)))
+			{
+				wurst.mods.flightMod.gotoGround();
+				updateLastMS();
+			}
+		}
 	}
 	
 	@Override


### PR DESCRIPTION
This feature works by instantly teleporting down and up in the same tick. It works up to a flying height (from ground up) of 300 blocks. Maybe more would work too, but I think this is too risky. It includes a new event, which needs changes to made in the vanilla code. More info about this is in the commit description. There is a new checkbox in both FlightMod and JetpackMod which can be used to disable this feature, because it causes faster regeneration, more traffic and no fall damage too.

![flightmod](https://cloud.githubusercontent.com/assets/10467401/13286764/a7606ad6-db03-11e5-83a4-57d002334f9e.PNG)

The [Kick: Safe] shows if the player is in a non-kickable height. If the player is too high, [Kick: Unsafe] shows right after the mod name, which means that the player can get kicked.

Please not that this feature won't work everytime (but this is very rare, mostly because of server lag or flying out of the loaded chunks). Also, there is no check about the block at the bottom (which can be fixed). Flying over Fire/Lava causes damage, items on the ground will be collected and so on. However, other players should not see you moving downwards/upwards. They think you don't change the position.